### PR TITLE
Add phone frame wrapper

### DIFF
--- a/app/components/PhoneFrame.tsx
+++ b/app/components/PhoneFrame.tsx
@@ -1,0 +1,27 @@
+"use client";
+import { Box } from "@mui/material";
+import React from "react";
+
+interface PhoneFrameProps {
+  children: React.ReactNode;
+}
+
+export default function PhoneFrame({ children }: PhoneFrameProps) {
+  return (
+    <Box
+      sx={{
+        width: 360,
+        height: 720,
+        backgroundImage:
+          "url(https://raw.githubusercontent.com/picturepan2/devices.css/master/docs/assets/img/bg-iphone-14-pro.jpg)",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        borderRadius: 4,
+        boxShadow: 3,
+        overflow: "hidden",
+      }}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,11 @@
-import ThemeProvider from './providers/ThemeProvider';
-import type { Metadata } from 'next';
+import ThemeProvider from "./providers/ThemeProvider";
+import type { Metadata } from "next";
+import { Box } from "@mui/material";
 
 export const metadata: Metadata = {
-  title: 'Quiz App',
-  description: 'Interactive quiz application built with Next.js and Material-UI',
+  title: "Quiz App",
+  description:
+    "Interactive quiz application built with Next.js and Material-UI",
 };
 
 export default function RootLayout({
@@ -15,7 +17,17 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ThemeProvider>
-          {children}
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "center",
+              alignItems: "center",
+              minHeight: "100vh",
+              backgroundColor: "#e0e0e0",
+            }}
+          >
+            {children}
+          </Box>
         </ThemeProvider>
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -104,22 +104,32 @@ export default function Home() {
   };
 
   if (!quizStarted) {
-    return <StartScreen onStart={handleStart} />;
+    return (
+      <PhoneFrame>
+        <StartScreen onStart={handleStart} />
+      </PhoneFrame>
+    );
   }
 
   if (quizFinished) {
-    return <EndScreen />;
+    return (
+      <PhoneFrame>
+        <EndScreen />
+      </PhoneFrame>
+    );
   }
 
   if (linaChatStarted) {
     return (
-      <LinaChat
-        currentQuestionIndex={currentQuestionIndex}
-        questions={questions}
-        onClose={handleClose}
-        onSkip={handleSkip}
-        onNextClicked={handleNextQuestion}
-      />
+      <PhoneFrame>
+        <LinaChat
+          currentQuestionIndex={currentQuestionIndex}
+          questions={questions}
+          onClose={handleClose}
+          onSkip={handleSkip}
+          onNextClicked={handleNextQuestion}
+        />
+      </PhoneFrame>
     );
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
 import { Container, Box } from "@mui/material";
+import PhoneFrame from "./components/PhoneFrame";
 import QuizHeader from "./components/QuizHeader";
 import ProgressBar from "./components/ProgressBar";
 import QuestionSection from "./components/QuestionSection";
@@ -123,56 +124,58 @@ export default function Home() {
   }
 
   return (
-    <Box
-      sx={{
-        minHeight: "100vh",
-        backgroundColor: "background.default",
-        display: "flex",
-        flexDirection: "column",
-      }}
-    >
-      <QuizHeader
-        onClose={handleClose}
-        onSkip={handleSkip}
-        isValidated={validated}
-      />
-
-      <ProgressBar
-        progress={currentQuestionIndex + 1}
-        total={questions.length}
-      />
-
-      <Container
-        maxWidth="sm"
+    <PhoneFrame>
+      <Box
         sx={{
-          flex: 1,
-          pb: 10,
-          px: { xs: 0, sm: 2 },
+          minHeight: "100vh",
+          backgroundColor: "background.default",
+          display: "flex",
+          flexDirection: "column",
         }}
       >
-        <QuestionSection
-          text={currentQuestion.text}
-          type={currentQuestion.type as "audio" | "text"}
-          content={currentQuestion.content}
+        <QuizHeader
+          onClose={handleClose}
+          onSkip={handleSkip}
+          isValidated={validated}
         />
 
-        <AnswerOptions
-          answers={currentQuestion.answers}
-          selectedAnswer={selectedAnswer}
-          onAnswerChange={handleAnswerChange}
-          validated={validated}
-          correctAnswerId={currentQuestion.correctAnswerId}
+        <ProgressBar
+          progress={currentQuestionIndex + 1}
+          total={questions.length}
         />
-      </Container>
 
-      {validated ? (
-        <ExplainButton onExplain={handleExplain} />
-      ) : (
-        <ValidateButton
-          onValidate={handleValidate}
-          disabled={!selectedAnswer}
-        />
-      )}
-    </Box>
+        <Container
+          maxWidth="sm"
+          sx={{
+            flex: 1,
+            pb: 10,
+            px: { xs: 0, sm: 2 },
+          }}
+        >
+          <QuestionSection
+            text={currentQuestion.text}
+            type={currentQuestion.type as "audio" | "text"}
+            content={currentQuestion.content}
+          />
+
+          <AnswerOptions
+            answers={currentQuestion.answers}
+            selectedAnswer={selectedAnswer}
+            onAnswerChange={handleAnswerChange}
+            validated={validated}
+            correctAnswerId={currentQuestion.correctAnswerId}
+          />
+        </Container>
+
+        {validated ? (
+          <ExplainButton onExplain={handleExplain} />
+        ) : (
+          <ValidateButton
+            onValidate={handleValidate}
+            disabled={!selectedAnswer}
+          />
+        )}
+      </Box>
+    </PhoneFrame>
   );
 }


### PR DESCRIPTION
## Summary
- add a `PhoneFrame` component using an online image of an iPhone
- wrap the home page inside the phone frame
- center the phone frame in the layout

## Testing
- `npm run build` *(fails: Cannot find module '@/components/ui/toast')*

------
https://chatgpt.com/codex/tasks/task_b_6853a2c05d548325ac0a1e7b8fe5af6e