### PR TITLE
Add phone frame wrapper

### DIFF
--- a/app/PhoneFrame.tsx
+++ b/app/PhoneFrame.tsx
@@ -1,0 +1,11 @@
+'use client';
+import React from 'react';
+import './phoneFrame.css';
+
+export default function PhoneFrame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="phone-frame">
+      <div className="phone-screen">{children}</div>
+    </div>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import ThemeProvider from './providers/ThemeProvider';
+import PhoneFrame from './PhoneFrame';
 import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
@@ -15,7 +16,9 @@ export default function RootLayout({
     <html lang="en">
       <body>
         <ThemeProvider>
-          {children}
+          <PhoneFrame>
+            {children}
+          </PhoneFrame>
         </ThemeProvider>
       </body>
     </html>

--- a/app/phoneFrame.css
+++ b/app/phoneFrame.css
@@ -1,0 +1,19 @@
+.phone-frame {
+  position: relative;
+  width: 375px;
+  height: 700px;
+  margin: 0 auto;
+  background: url("https://raw.githubusercontent.com/hfg-gmuend/openmoji/master/src/objects/phone/1F4F1.svg") no-repeat center/contain;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.phone-screen {
+  position: absolute;
+  top: 12%;
+  left: 11%;
+  width: 78%;
+  height: 76%;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Summary
- add `PhoneFrame` component with CSS for a simple phone effect
- wrap the app layout with the new phone frame

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module '@/components/ui/toast')*

------
https://chatgpt.com/codex/tasks/task_b_6853a2c05d548325ac0a1e7b8fe5af6e